### PR TITLE
Nested chains - DO NOT MERGE

### DIFF
--- a/diuf/sudoku/Grid.java
+++ b/diuf/sudoku/Grid.java
@@ -9,6 +9,7 @@ package diuf.sudoku;
 import java.util.*;
 
 import diuf.sudoku.tools.CellSet;
+import diuf.sudoku.tools.DigitCells;
 
 /**
  * A Sudoku grid.
@@ -31,6 +32,16 @@ public class Grid {
      * Cell potential values of the grid, bit 0 is unused.
      */
     private BitSet[] cellPotentialValues = new BitSet[81];
+
+    /*
+     * The grid state at entry of the current hint search cycle.
+     */
+    private Grid initialGrid = null;
+
+    /*
+     * The grid state at entry of the current hint search cycle.
+     */
+    private DigitCells dCells = null;
 
 //    //cache for Region.getPotentialPositions(value)
 //    private valueCells valueCellsCache = new valueCells();
@@ -369,8 +380,32 @@ public class Grid {
     public static Grid.Region getRegionAt(int regionTypeIndex, int cellIndex) {
         return Grid.regions[regionTypeIndex][Grid.cellRegions[cellIndex][regionTypeIndex]];
     }
+    
+    public static Grid.Region getCommonRegion(int cellIndex1, int cellIndex2) {
+    	//TODO: move to table 81x81
+    	for(int regionTypeIndex = 0; regionTypeIndex < 3; regionTypeIndex++) {
+    		if(cellRegions[cellIndex1][regionTypeIndex] == cellRegions[cellIndex2][regionTypeIndex]) {
+    	        return regions[regionTypeIndex][Grid.cellRegions[cellIndex1][regionTypeIndex]];
+    		}
+    	}
+        return null;
+    }
 
     //=== Non-static methods ==============
+
+    public Grid getInitialGrid() {
+    	return initialGrid;
+    }
+    public void setInitialGrid(Grid g) {
+    	if(initialGrid == null) initialGrid = new Grid();
+    	g.copyTo(initialGrid);
+    }
+    public DigitCells getDigitCells() {
+    	return dCells;
+    }
+    public void rebuildDigitCells() {
+    	dCells = new DigitCells(this);
+    }
 
     /**
      * Set the value of a cell

--- a/diuf/sudoku/Grid.java
+++ b/diuf/sudoku/Grid.java
@@ -571,6 +571,9 @@ public class Grid {
             other.setCellValue(i, this.cellValues[i]);
             other.setCellPotentialValues(i, cellPotentialValues[i]);
         }
+        other.initialGrid = initialGrid; //copy reference assuming constant
+        if(other.dCells != null) dCells = new DigitCells(other); //copy by value or clear
+        else dCells = null;
 //        //clone the cache as well
 //        for(int regionType = 0; regionType < 3; regionType++) {
 //            for(int region = 0; region < 9; region++) {

--- a/diuf/sudoku/Grid.java
+++ b/diuf/sudoku/Grid.java
@@ -400,11 +400,17 @@ public class Grid {
     	if(initialGrid == null) initialGrid = new Grid();
     	g.copyTo(initialGrid);
     }
+    public void clearInitialGrid() {
+    	initialGrid = null;
+    }
     public DigitCells getDigitCells() {
     	return dCells;
     }
     public void rebuildDigitCells() {
     	dCells = new DigitCells(this);
+    }
+    public void clearDigitCells() {
+    	dCells = null;
     }
 
     /**

--- a/diuf/sudoku/solver/Solver.java
+++ b/diuf/sudoku/solver/Solver.java
@@ -875,6 +875,7 @@ else {
 						break;
 					}
 				}
+				HintsCache.purge(grid);
 				if ( difficulty == 20.0 ) {
 					break;
 				}

--- a/diuf/sudoku/solver/Solver.java
+++ b/diuf/sudoku/solver/Solver.java
@@ -229,12 +229,13 @@ else {
         addIfWorth(SolvingTechnique.NestedForcingChain, advancedHintProducers, new Chaining(true, true, false, 2, false, 0));
         addIfWorth(SolvingTechnique.NestedForcingChain, advancedHintProducers, new Chaining(true, true, false, 3, false, 0));
         experimentalHintProducers = new ArrayList<IndirectHintProducer>(); // Two levels of nesting !?
-        addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 0));
-        addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 1));
-        addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 2));
-        addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 3)); //MD: highly experimental
-        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 5));
-        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 6));
+        addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 0)); //required still for vanilla
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 1));
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 2));
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 4, false, 3)); //MD: highly experimental
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 5, false, 0));
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 5, false, 1));
+        //addIfWorth(SolvingTechnique.NestedForcingChain, experimentalHintProducers, new Chaining(true, true, false, 6, false, 0));
 }
 	}
 
@@ -599,7 +600,7 @@ else {
             	formatter.beforeHint(this);
             	Hint hint = null;
             	try {
-            		grid.setInitialGrid(grid);
+            		//grid.setInitialGrid(grid);
             		hint = getSingleHint();
             		if(hint != null) {
 		                assert hint instanceof Rule;
@@ -760,6 +761,7 @@ else {
     public void getBatchDifficulty(serate.Formatter formatter) {
         Grid backup = new Grid();
         grid.copyTo(backup);
+		HintsCache.clear();
 		boolean logStep = Settings.getInstance().isLog();
 		PrintWriter logWriter = Settings.getInstance().getLogWriter();
 		int batchCount = 0;
@@ -778,7 +780,7 @@ else {
 				formatter.beforeHint(this);
 				List<Hint> result = new ArrayList<Hint>();
 				SmallestHintsAccumulator accu = new SmallestHintsAccumulator(result);
-        		grid.setInitialGrid(grid);
+        		//grid.setInitialGrid(grid);
                 try {
                     for (HintProducer producer : directHintProducers) {
                         producer.getHints(grid, accu);
@@ -883,6 +885,7 @@ else {
 			formatter.afterPuzzle(this);
 		}
 		finally {
+			HintsCache.clear();
             backup.copyTo(grid);
         }
     }

--- a/diuf/sudoku/solver/Solver.java
+++ b/diuf/sudoku/solver/Solver.java
@@ -599,6 +599,7 @@ else {
             	formatter.beforeHint(this);
             	Hint hint = null;
             	try {
+            		grid.setInitialGrid(grid);
             		hint = getSingleHint();
             		if(hint != null) {
 		                assert hint instanceof Rule;
@@ -777,6 +778,7 @@ else {
 				formatter.beforeHint(this);
 				List<Hint> result = new ArrayList<Hint>();
 				SmallestHintsAccumulator accu = new SmallestHintsAccumulator(result);
+        		grid.setInitialGrid(grid);
                 try {
                     for (HintProducer producer : directHintProducers) {
                         producer.getHints(grid, accu);

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -29,7 +29,7 @@ public class Chaining implements IndirectHintProducer {
     private final boolean isDynamic;
     private final boolean isNisho;
     private final int level;
-    private final boolean noParallel;
+    private final boolean isNested;
     private final int nestingLimit;
     //private Grid saveGrid = null;
     //private Grid saveGrid = new Grid();
@@ -56,13 +56,14 @@ public class Chaining implements IndirectHintProducer {
 //        this.nestingLimit = 0;
 //    }
     
-    public Chaining(boolean isMultipleEnabled, boolean isDynamic, boolean isNishio, int level, boolean noParallel, int nestingLimit) {
+    public Chaining(boolean isMultipleEnabled, boolean isDynamic, boolean isNishio, int level, boolean isNested, int nestingLimit) {
         this.isMultipleEnabled = isMultipleEnabled;
         this.isDynamic = isDynamic;
         this.isNisho = isNishio;
         this.level = level;
-        this.noParallel = noParallel;
+        this.isNested = isNested;
         this.nestingLimit = nestingLimit;
+        //signature = "Chaining" + (isMultipleEnabled ? "1" : "0") + (isDynamic ? "1" : "0") + (isNisho ? "1" : "0") + String.valueOf(level) + (isNested ? "1" : "0") + String.valueOf(nestingLimit);
         signature = "Chaining" + (isMultipleEnabled ? "1" : "0") + (isDynamic ? "1" : "0") + (isNisho ? "1" : "0") + String.valueOf(level) + String.valueOf(nestingLimit);
     }
 
@@ -261,7 +262,7 @@ public class Chaining implements IndirectHintProducer {
         List<ChainingHint> result = new ArrayList<ChainingHint>();
         //boolean noParallel = true; //debug, hide the class member noParallel
         //boolean noParallel = false;
-        boolean noParallel = this.noParallel || Settings.getInstance().getNumThreads() == 1;
+        boolean noParallel = this.isNested || Settings.getInstance().getNumThreads() == 1;
         List<Cell> cellsToProcess = new ArrayList<Cell>();
         // Iterate on all empty cells
         for (int i = 0; i < 81; i++) {
@@ -1306,8 +1307,8 @@ public class Chaining implements IndirectHintProducer {
     	Iterable<ChainingHint> cachedHints = HintsCache.get(grid, signature);
     	if(cachedHints != null) {
         	//System.err.printf("(%d%d%d% d%d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit);
-            for (Hint hint : cachedHints) {
-                accu.add((ChainingHint)hint);
+            for (ChainingHint hint : cachedHints) {
+                accu.add(hint);
             }
             return;
     	}

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -34,8 +34,8 @@ public class Chaining implements IndirectHintProducer {
     //private Grid saveGrid = null;
     //private Grid saveGrid = new Grid();
     private List<IndirectHintProducer> otherRules;
-    private Grid lastGrid = null;
-    private Collection<ChainingHint> lastHints = null;
+    //private Grid lastGrid = null;
+    //private Collection<ChainingHint> lastHints = null;
     private String signature;
 
 
@@ -1297,10 +1297,10 @@ public class Chaining implements IndirectHintProducer {
             return "Forcing Chains & Cycles";
     }
 
-    private void getPreviousHints(HintsAccumulator accu) throws InterruptedException {
-        for (ChainingHint hint : lastHints)
-            accu.add(hint);
-    }
+//    private void getPreviousHints(HintsAccumulator accu) throws InterruptedException {
+//        for (ChainingHint hint : lastHints)
+//            accu.add(hint);
+//    }
 
     public void getHints(Grid grid, HintsAccumulator accu) throws InterruptedException {
     	Iterable<ChainingHint> cachedHints = HintsCache.get(grid, signature);
@@ -1312,27 +1312,27 @@ public class Chaining implements IndirectHintProducer {
             return;
     	}
     	
-        if (lastGrid != null && grid.equals(lastGrid)) {
-        	//System.err.printf("(%d%d%d% d%d %d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit, lastHints.size());
-            getPreviousHints(accu);
-            return;
-        }
+//        if (lastGrid != null && grid.equals(lastGrid)) {
+//        	//System.err.printf("(%d%d%d% d%d %d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit, lastHints.size());
+//            getPreviousHints(accu);
+//            return;
+//        }
     	//System.err.print('-');
         List<ChainingHint> result = getHintList(grid);
         HintsCache.put(grid, signature, result);
-        lastGrid = new Grid();
-        grid.copyTo(lastGrid);
-        //if(Settings.getInstance().getBestHintOnly()) {
-        if(accu instanceof SingleHintAccumulator) { 
-            lastHints = new LinkedHashSet<ChainingHint>();
-            if(! result.isEmpty()) {
-            	lastHints.add(result.get(0));
-            }
-        }
-        else {
+//        lastGrid = new Grid();
+//        grid.copyTo(lastGrid);
+//        //if(Settings.getInstance().getBestHintOnly()) {
+//        if(accu instanceof SingleHintAccumulator) { 
+//            lastHints = new LinkedHashSet<ChainingHint>();
+//            if(! result.isEmpty()) {
+//            	lastHints.add(result.get(0));
+//            }
+//        }
+//        else {
 	        // This filters hints that are equal:
-	        lastHints = new LinkedHashSet<ChainingHint>(result);
-        }
+        	Collection<ChainingHint> lastHints = new LinkedHashSet<ChainingHint>(result);
+//        }
         for (IndirectHint hint : lastHints)
             accu.add(hint);
     }

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -36,6 +36,7 @@ public class Chaining implements IndirectHintProducer {
     private List<IndirectHintProducer> otherRules;
     private Grid lastGrid = null;
     private Collection<ChainingHint> lastHints = null;
+    private String signature;
 
 
     /**
@@ -62,6 +63,7 @@ public class Chaining implements IndirectHintProducer {
         this.level = level;
         this.noParallel = noParallel;
         this.nestingLimit = nestingLimit;
+        signature = "Chaining" + (isMultipleEnabled ? "1" : "0") + (isDynamic ? "1" : "0") + (isNisho ? "1" : "0") + String.valueOf(level) + String.valueOf(nestingLimit);
     }
 
     boolean isDynamic() {
@@ -1301,6 +1303,15 @@ public class Chaining implements IndirectHintProducer {
     }
 
     public void getHints(Grid grid, HintsAccumulator accu) throws InterruptedException {
+    	Iterable<ChainingHint> cachedHints = HintsCache.get(grid, signature);
+    	if(cachedHints != null) {
+        	//System.err.printf("(%d%d%d% d%d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit);
+            for (Hint hint : cachedHints) {
+                accu.add((ChainingHint)hint);
+            }
+            return;
+    	}
+    	
         if (lastGrid != null && grid.equals(lastGrid)) {
         	//System.err.printf("(%d%d%d% d%d %d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit, lastHints.size());
             getPreviousHints(accu);
@@ -1308,6 +1319,7 @@ public class Chaining implements IndirectHintProducer {
         }
     	//System.err.print('-');
         List<ChainingHint> result = getHintList(grid);
+        HintsCache.put(grid, signature, result);
         lastGrid = new Grid();
         grid.copyTo(lastGrid);
         //if(Settings.getInstance().getBestHintOnly()) {

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -575,102 +575,53 @@ public class Chaining implements IndirectHintProducer {
      * @param p the potential that is assumed to be "on"
      * @return the set of potentials that must be "off"
      */
-    private Set<Potential> getOnToOff(Grid grid, Potential p, boolean isYChainEnabled) {
-if (Settings.getInstance().Fixed14Chaining() == 1) {
-		LinkedSet<Potential> result = new LinkedSet<Potential>();
-
-        int potentialCellIndex = p.cell.getIndex();
-        if (isYChainEnabled) { // This rule is not used with X-Chains
-            // First rule: other potential values for this cell get off
-            BitSet potentialValues = grid.getCellPotentialValues(potentialCellIndex);
-            for (int value = potentialValues.nextSetBit(0); value >= 0; value = potentialValues.nextSetBit(value + 1)) {
-                if (value != p.value)
-                    result.add(new Potential(p.cell, value, false, p,
-                            Potential.Cause.NakedSingle, "the cell can contain only one value"));
-            }
-        }
-
-        // Second rule: other potential position for this value get off
-        Grid.Region box = Grid.getRegionAt(0, potentialCellIndex);
-        BitSet boxPositions = box.copyPotentialPositions(grid, p.value);
-        boxPositions.clear(box.indexOf(p.cell));
-        for (int i = boxPositions.nextSetBit(0); i >= 0; i = boxPositions.nextSetBit(i + 1)) {
-            Cell cell = box.getCell(i);
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(0),
-                    "the value can occur only once in the " + box.toString()));
-        }
-        Grid.Region row = Grid.getRegionAt(1, potentialCellIndex);
-        BitSet rowPositions = row.copyPotentialPositions(grid, p.value);
-        rowPositions.clear(row.indexOf(p.cell));
-        for (int i = rowPositions.nextSetBit(0); i >= 0; i = rowPositions.nextSetBit(i + 1)) {
-            Cell cell = row.getCell(i);
-            if(box.contains(cell)) continue;
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(1),
-                    "the value can occur only once in the " + row.toString()));
-        }
-        Grid.Region col = Grid.getRegionAt(2, potentialCellIndex);
-        BitSet colPositions = col.copyPotentialPositions(grid, p.value);
-        colPositions.clear(col.indexOf(p.cell));
-        for (int i = colPositions.nextSetBit(0); i >= 0; i = colPositions.nextSetBit(i + 1)) {
-            Cell cell = col.getCell(i);
-            if(box.contains(cell)) continue;
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(2),
-                    "the value can occur only once in the " + col.toString()));
-        }
-
-        return result;
-}
-else{
-    	Set<Potential> result = new LinkedHashSet<Potential>();
-
-        int potentialCellIndex = p.cell.getIndex();
-        if (isYChainEnabled) { // This rule is not used with X-Chains
-            // First rule: other potential values for this cell get off
-            BitSet potentialValues = grid.getCellPotentialValues(potentialCellIndex);
-            for (int value = potentialValues.nextSetBit(0); value >= 0; value = potentialValues.nextSetBit(value + 1)) {
-                if (value != p.value)
-                    result.add(new Potential(p.cell, value, false, p,
-                            Potential.Cause.NakedSingle, "the cell can contain only one value"));
-            }
-        }
-
-        // Second rule: other potential position for this value get off
-        Grid.Region box = Grid.getRegionAt(0, potentialCellIndex);
-        BitSet boxPositions = box.copyPotentialPositions(grid, p.value);
-        boxPositions.clear(box.indexOf(p.cell));
-        for (int i = boxPositions.nextSetBit(0); i >= 0; i = boxPositions.nextSetBit(i + 1)) {
-            Cell cell = box.getCell(i);
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(0),
-                    "the value can occur only once in the " + box.toString()));
-        }
-        Grid.Region row = Grid.getRegionAt(1, potentialCellIndex);
-        BitSet rowPositions = row.copyPotentialPositions(grid, p.value);
-        rowPositions.clear(row.indexOf(p.cell));
-        for (int i = rowPositions.nextSetBit(0); i >= 0; i = rowPositions.nextSetBit(i + 1)) {
-            Cell cell = row.getCell(i);
-            if(box.contains(cell)) continue;
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(1),
-                    "the value can occur only once in the " + row.toString()));
-        }
-        Grid.Region col = Grid.getRegionAt(2, potentialCellIndex);
-        BitSet colPositions = col.copyPotentialPositions(grid, p.value);
-        colPositions.clear(col.indexOf(p.cell));
-        for (int i = colPositions.nextSetBit(0); i >= 0; i = colPositions.nextSetBit(i + 1)) {
-            Cell cell = col.getCell(i);
-            if(box.contains(cell)) continue;
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(2),
-                    "the value can occur only once in the " + col.toString()));
-        }
-
-        return result;
-}
-    }
+//    private Set<Potential> getOnToOff(Grid grid, Potential p, boolean isYChainEnabled) {
+//    	Set<Potential> result = new LinkedHashSet<Potential>();
+//
+//        int potentialCellIndex = p.cell.getIndex();
+//        if (isYChainEnabled) { // This rule is not used with X-Chains
+//            // First rule: other potential values for this cell get off
+//            BitSet potentialValues = grid.getCellPotentialValues(potentialCellIndex);
+//            for (int value = potentialValues.nextSetBit(0); value >= 0; value = potentialValues.nextSetBit(value + 1)) {
+//                if (value != p.value)
+//                    result.add(new Potential(p.cell, value, false, p,
+//                            Potential.Cause.NakedSingle, "the cell can contain only one value"));
+//            }
+//        }
+//
+//        // Second rule: other potential position for this value get off
+//        Grid.Region box = Grid.getRegionAt(0, potentialCellIndex);
+//        BitSet boxPositions = box.copyPotentialPositions(grid, p.value);
+//        boxPositions.clear(box.indexOf(p.cell));
+//        for (int i = boxPositions.nextSetBit(0); i >= 0; i = boxPositions.nextSetBit(i + 1)) {
+//            Cell cell = box.getCell(i);
+//            result.add(new Potential(cell, p.value, false, p,
+//                    getRegionCause(0),
+//                    "the value can occur only once in the " + box.toString()));
+//        }
+//        Grid.Region row = Grid.getRegionAt(1, potentialCellIndex);
+//        BitSet rowPositions = row.copyPotentialPositions(grid, p.value);
+//        rowPositions.clear(row.indexOf(p.cell));
+//        for (int i = rowPositions.nextSetBit(0); i >= 0; i = rowPositions.nextSetBit(i + 1)) {
+//            Cell cell = row.getCell(i);
+//            if(box.contains(cell)) continue;
+//            result.add(new Potential(cell, p.value, false, p,
+//                    getRegionCause(1),
+//                    "the value can occur only once in the " + row.toString()));
+//        }
+//        Grid.Region col = Grid.getRegionAt(2, potentialCellIndex);
+//        BitSet colPositions = col.copyPotentialPositions(grid, p.value);
+//        colPositions.clear(col.indexOf(p.cell));
+//        for (int i = colPositions.nextSetBit(0); i >= 0; i = colPositions.nextSetBit(i + 1)) {
+//            Cell cell = col.getCell(i);
+//            if(box.contains(cell)) continue;
+//            result.add(new Potential(cell, p.value, false, p,
+//                    getRegionCause(2),
+//                    "the value can occur only once in the " + col.toString()));
+//        }
+//
+//        return result;
+//    }
 
     private Set<Potential> getOnToOff(Grid grid, Potential p, boolean isYChainEnabled, DigitCells dc) {
     	Set<Potential> result = new LinkedHashSet<Potential>();
@@ -770,115 +721,55 @@ else{
      * @param p the potential that is assumed to be "off"
      * @return the set of potentials that must be "on"
      */
-    private Set<Potential> getOffToOn(Grid grid, Potential p, Grid source,
-            LinkedSet<Potential> offPotentials, boolean isYChainEnabled,
-            boolean isXChainEnabled) {
-if (Settings.getInstance().Fixed14Chaining() == 1) {
-		//Set<Potential> result = new LinkedHashSet<Potential>();
-    	LinkedSet<Potential> result = new LinkedSet<Potential>();
-															  
-    	int thisCellIndex = p.cell.getIndex();
-        if (isYChainEnabled) {
-            // First rule: if there is only two potentials in this cell, the other one gets on
-            BitSet potentialValues = grid.getCellPotentialValues(thisCellIndex);
-            if (potentialValues.cardinality() == 2) {
-                int otherValue = potentialValues.nextSetBit(0);
-                if (otherValue == p.value)
-                    otherValue = potentialValues.nextSetBit(otherValue + 1);
-                Potential pOn = new Potential(p.cell, otherValue, true, p,
-                        Potential.Cause.NakedSingle, "only remaining possible value in the cell");
-                addHiddenParentsOfCell(pOn, grid, source, offPotentials);
-                result.add(pOn);
-            }
-        }
-
-        if (isXChainEnabled) {
-            // Second rule: if there are only two positions for this potential, the other one gets on
-        	int thisValue = p.value;
-        	for(int regionTypeIndex = 0; regionTypeIndex < 3; regionTypeIndex++) {
-        		Region r = Grid.regions[regionTypeIndex][Grid.cellRegions[thisCellIndex][regionTypeIndex]];
-	        	int otherPosition = -1;
-	        	for(int regionCellIndex = 0; regionCellIndex < 9; regionCellIndex++) {
-	        		int cellIndex = r.getCell(regionCellIndex).getIndex();
-	        		if(cellIndex == thisCellIndex) continue;
-	        		if(grid.hasCellPotentialValue(cellIndex, thisValue)) {
-	        			if(otherPosition >= 0) { //third cell in a house has this candidate
-	        				otherPosition = -1;
-	        				break;
-	        			}
-	        			otherPosition = cellIndex;
-	        		}
-	        	} //region cells
-	        	if(otherPosition >= 0) { //exactly one other position
-                    Potential pOn = new Potential(Grid.getCell(otherPosition), thisValue, true, p,
-                            getRegionCause(regionTypeIndex),
-                            "only remaining possible position in the " + r.toString());
-                    addHiddenParentsOfRegion(pOn, grid, source, r, offPotentials);
-
-					if (!result.contains(pOn))
-						result.add(pOn);
-					else {
-						Potential pCell = result.get(pOn);
-						if (pOn.getAncestorCount() < pCell.getAncestorCount()) {
-							result.remove(pCell);
-							result.add(pOn);
-						}
-					}
-	  
-	        	}
-        	} // region types
-        }
-
-        return result;
-}
-else {
-		Set<Potential> result = new LinkedHashSet<Potential>();
-															  
-    	int thisCellIndex = p.cell.getIndex();
-        if (isYChainEnabled) {
-            // First rule: if there is only two potentials in this cell, the other one gets on
-            BitSet potentialValues = grid.getCellPotentialValues(thisCellIndex);
-            if (potentialValues.cardinality() == 2) {
-                int otherValue = potentialValues.nextSetBit(0);
-                if (otherValue == p.value)
-                    otherValue = potentialValues.nextSetBit(otherValue + 1);
-                Potential pOn = new Potential(p.cell, otherValue, true, p,
-                        Potential.Cause.NakedSingle, "only remaining possible value in the cell");
-                addHiddenParentsOfCell(pOn, grid, source, offPotentials);
-                result.add(pOn);
-            }
-        }
-
-        if (isXChainEnabled) {
-            // Second rule: if there are only two positions for this potential, the other one gets on
-        	int thisValue = p.value;
-        	for(int regionTypeIndex = 0; regionTypeIndex < 3; regionTypeIndex++) {
-        		Region r = Grid.regions[regionTypeIndex][Grid.cellRegions[thisCellIndex][regionTypeIndex]];
-	        	int otherPosition = -1;
-	        	for(int regionCellIndex = 0; regionCellIndex < 9; regionCellIndex++) {
-	        		int cellIndex = r.getCell(regionCellIndex).getIndex();
-	        		if(cellIndex == thisCellIndex) continue;
-	        		if(grid.hasCellPotentialValue(cellIndex, thisValue)) {
-	        			if(otherPosition >= 0) { //third cell in a house has this candidate
-	        				otherPosition = -1;
-	        				break;
-	        			}
-	        			otherPosition = cellIndex;
-	        		}
-	        	} //region cells
-	        	if(otherPosition >= 0) { //exactly one other position
-                    Potential pOn = new Potential(Grid.getCell(otherPosition), thisValue, true, p,
-                            getRegionCause(regionTypeIndex),
-                            "only remaining possible position in the " + r.toString());
-                    addHiddenParentsOfRegion(pOn, grid, source, r, offPotentials);						   
-                    result.add(pOn);	   	  
-	        	}
-        	} // region types
-        }
-
-        return result;
-}
-    }
+//    private Set<Potential> getOffToOn(Grid grid, Potential p, Grid source,
+//            LinkedSet<Potential> offPotentials, boolean isYChainEnabled,
+//            boolean isXChainEnabled) {
+//		Set<Potential> result = new LinkedHashSet<Potential>();
+//															  
+//    	int thisCellIndex = p.cell.getIndex();
+//        if (isYChainEnabled) {
+//            // First rule: if there is only two potentials in this cell, the other one gets on
+//            BitSet potentialValues = grid.getCellPotentialValues(thisCellIndex);
+//            if (potentialValues.cardinality() == 2) {
+//                int otherValue = potentialValues.nextSetBit(0);
+//                if (otherValue == p.value)
+//                    otherValue = potentialValues.nextSetBit(otherValue + 1);
+//                Potential pOn = new Potential(p.cell, otherValue, true, p,
+//                        Potential.Cause.NakedSingle, "only remaining possible value in the cell");
+//                addHiddenParentsOfCell(pOn, grid, source, offPotentials);
+//                result.add(pOn);
+//            }
+//        }
+//
+//        if (isXChainEnabled) {
+//            // Second rule: if there are only two positions for this potential, the other one gets on
+//        	int thisValue = p.value;
+//        	for(int regionTypeIndex = 0; regionTypeIndex < 3; regionTypeIndex++) {
+//        		Region r = Grid.regions[regionTypeIndex][Grid.cellRegions[thisCellIndex][regionTypeIndex]];
+//	        	int otherPosition = -1;
+//	        	for(int regionCellIndex = 0; regionCellIndex < 9; regionCellIndex++) {
+//	        		int cellIndex = r.getCell(regionCellIndex).getIndex();
+//	        		if(cellIndex == thisCellIndex) continue;
+//	        		if(grid.hasCellPotentialValue(cellIndex, thisValue)) {
+//	        			if(otherPosition >= 0) { //third cell in a house has this candidate
+//	        				otherPosition = -1;
+//	        				break;
+//	        			}
+//	        			otherPosition = cellIndex;
+//	        		}
+//	        	} //region cells
+//	        	if(otherPosition >= 0) { //exactly one other position
+//                    Potential pOn = new Potential(Grid.getCell(otherPosition), thisValue, true, p,
+//                            getRegionCause(regionTypeIndex),
+//                            "only remaining possible position in the " + r.toString());
+//                    addHiddenParentsOfRegion(pOn, grid, source, r, offPotentials);						   
+//                    result.add(pOn);	   	  
+//	        	}
+//        	} // region types
+//        }
+//
+//        return result;
+//    }
 
     private Set<Potential> getOffToOn(Grid grid, Potential p, Grid source, LinkedSet<Potential> offPotentials, boolean isYChainEnabled, boolean isXChainEnabled, DigitCells dc) {
 		Set<Potential> result = new LinkedHashSet<Potential>();
@@ -1053,77 +944,8 @@ else {
     private Potential[] doChaining(Grid grid, LinkedSet<Potential> toOn, LinkedSet<Potential> toOff, DigitCells dc) {
     	//MD: Note that toOn potentials have higher precedence than toOff which can result in non-shortest contradiction chain finding.
     	saveGrid = new Grid();
-        grid.copyTo(saveGrid);
-if (Settings.getInstance().Fixed14Chaining() == 1){
-		Potential[] pOnRes = new Potential[729];
-		Potential[] pOffRes = new Potential[729];
-		int numRes = 0;
-		try {
-            List<Potential> pendingOn = new LinkedList<Potential>(toOn);
-            List<Potential> pendingOff = new LinkedList<Potential>(toOff);
-            while (!pendingOn.isEmpty() || !pendingOff.isEmpty()) {
-                if (!pendingOn.isEmpty()) {
-                    Potential p = pendingOn.remove(0);
-                    Set<Potential> makeOff = getOnToOff(grid, p, !isNisho);
-	                for (Potential pOff : makeOff) {
-	                    Potential pOn = new Potential(pOff.cell, pOff.value, true); // Conjugate
-	                    if (toOn.contains(pOn)) {
-	                        // Contradiction found
-							pOnRes[numRes] = toOn.get(pOn); // Retrieve version of conjugate with parents
-							pOffRes[numRes++] = pOff;
-	                    } else if (!toOff.contains(pOff)) {
-	                        // Not processed yet
-	                        toOff.add(pOff);
-	                        pendingOff.add(pOff);
-	                   }
-	                }
-                } else {
-                    Potential p = pendingOff.remove(0);
-                    Set<Potential> makeOn = getOffToOn(grid, p, saveGrid, toOff, !isNisho, true);
-                    if (isDynamic)
-                        p.off(grid); // writes to grid
-	                for (Potential pOn : makeOn) {
-	                    Potential pOff = new Potential(pOn.cell, pOn.value, false); // Conjugate
-	                    if (toOff.contains(pOff)) {
-	                        // Contradiction found
-							pOnRes[numRes] = pOn; // Retrieve version of conjugate with parents
-							pOffRes[numRes++] = toOff.get(pOff);
-	                    } else if (!toOn.contains(pOn)) {
-	                        // Not processed yet
-	                        toOn.add(pOn);
-	                        pendingOn.add(pOn);
-						}
-	                }
-				}
-				if (numRes > 0) {
-					// Take minimal length contradiction out of all found
-					int minK = 0;
-					int minKVal = pOnRes[0].getAncestorCount() + pOffRes[0].getAncestorCount();
-					for (int k=1;k<numRes;++k) {
-						int curKVal = pOnRes[k].getAncestorCount() + pOffRes[k].getAncestorCount();
-						if ( curKVal < minKVal ) {
-							minKVal = curKVal;
-							minK = k;
-						}
-					}
-					return new Potential[] {pOnRes[minK], pOffRes[minK]}; // Cannot be both on and off at the same time 
-				}
-                if (level > 0 && pendingOn.isEmpty() && pendingOff.isEmpty()) {
-                    for (Potential pOff : getAdvancedPotentials(grid, saveGrid, toOff)) {
-                        if (!toOff.contains(pOff)) {
-                            // Not processed yet
-                            toOff.add(pOff);
-                            pendingOff.add(pOff);
-                        }
-                    }
-                }
-            }
-            return null;
-        } finally {
-            saveGrid.copyTo(grid);
-        }
-}
-else{										  										   
+        grid.copyTo(saveGrid); //MD: this is used not only for restoration of the original grid on exit, but also in parents search
+									   
 		DigitCells dcCopy = new DigitCells(dc);
         try {
             Queue<Potential> pendingOn = new LinkedList<Potential>(toOn);
@@ -1183,7 +1005,6 @@ else{
         } finally {
             saveGrid.copyTo(grid);
         }
-}
     }
 
     /**
@@ -1240,87 +1061,6 @@ else{
         int index = 0;
         while (index < otherRules.size() && result.isEmpty()) {
             IndirectHintProducer rule = otherRules.get(index);
-if (Settings.getInstance().Fixed14Chaining() == 1){
-            try {
-                rule.getHints(grid, new HintsAccumulator() {
-                    public void add(Hint hint0) {
-                        IndirectHint hint = (IndirectHint)hint0;
-                        Collection<Potential> parents =
-                            ((HasParentPotentialHint)hint).getRuleParents(source, grid);
-                        /*
-                         * If no parent can be found, the rule probably already exists without
-                         * the chain. Therefore it is useless to include it in the chain.
-                         */
-                        if (!parents.isEmpty()) {
-                            ChainingHint nested = null;
-                            if (hint instanceof ChainingHint)
-                                nested = (ChainingHint)hint;
-                            Map<Cell, BitSet> removable = hint.getRemovablePotentials();
-                            assert !removable.isEmpty();
-//This is the start of the modified section  that needs a look into
-			                // lksudoku: We sort the removable potentials so that all runs will yield the 
-                            // same resulting chains, if not sorted, same puzzle may get different chains
-                            // when there are different chains for same contradiction, thus causing different
-                            // rating of same puzzle at different times
-							List<Cell> sortedRemKeys=new ArrayList<Cell>(removable.keySet());
-					        Collections.sort(sortedRemKeys, new Comparator<Cell>() {
-					            public int compare(Cell c1, Cell c2) {
-					            	if (c1.getX() != c2.getX())
-					            		return c1.getX() - c2.getX();
-					            	if (c1.getY() != c2.getY())
-					            		return c1.getY() - c2.getY();
-					            	return grid.getCellPotentialValues(c1.getIndex()).nextSetBit(0)-grid.getCellPotentialValues(c2.getIndex()).nextSetBit(0);
-					            }
-					        });
-							////for (Cell cell : removable.keySet()) {
-                            //for (Map.Entry<Cell, BitSet> entry : sortedRemKeys) {
-                            //	Cell cell = entry.getKey();
-                            //    BitSet values = entry.getValue();
-                            for (Cell cell : sortedRemKeys) {
-                                BitSet values = removable.get(cell);
-//This is the end of the modified section  that needs a look into
-
-//This is the start of the section  that shows lksudoku original code
-/*
-                            // lksudoku: We sort the removable potentials so that all runs will yield the 
-                            // same resulting chains, if not sorted, same puzzle may get different chains
-                            // when there are different chains for same contradition, thus causing different
-                            // rating of same puzzle at different times
-							List<Cell> sortedRemKeys=new ArrayList<Cell>(removable.keySet());
-					        Collections.sort(sortedRemKeys, new Comparator<Cell>() {
-					            public int compare(Cell c1, Cell c2) {
-					            	if (c1.getX() != c2.getX())
-					            		return c1.getX() - c2.getX();
-					            	if (c1.getY() != c2.getY())
-					            		return c1.getY() - c2.getY();
-					            	return c1.getPotentialValues().nextSetBit(0)-c2.getPotentialValues().nextSetBit(0);
-					            }
-					        });
-
-                            for (Cell cell : sortedRemKeys) {
-*/
-//This is the end of the section  that shows lksudoku original code
-
-
-                                for (int value = values.nextSetBit(0); value != -1; value = values.nextSetBit(value + 1)) {
-                                    //Potential.Cause cause = Potential.Cause.Advanced;
-                                    Potential toOff = new Potential(cell, value, false, Potential.Cause.Advanced, hint.toString(), nested);
-                                    for (Potential p : parents) {
-                                        Potential real = offPotentials.get(p);
-                                        assert real != null;
-                                        toOff.parents.add(real);
-                                    }
-                                    result.add(toOff);
-                                }
-                            }
-                        }
-                    }
-                });
-            } catch(InterruptedException ex) {
-                ex.printStackTrace();
-            }
-}
-else {
             try {
                 rule.getHints(grid, new HintsAccumulator() {
                     public void add(Hint hint0) {
@@ -1359,7 +1099,6 @@ else {
             } catch(InterruptedException ex) {
                 ex.printStackTrace();
             }
-}
             index++;
         }
         return result;

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -637,13 +637,33 @@ public class Chaining implements IndirectHintProducer {
         // Second rule: other potential position for this value get off
 		CellSet victims = new CellSet(Grid.visibleCellsSet[potentialCellIndex]);
 		victims.bits.and(dc.digitCells[p.value - 1]);
-        for(Cell cell : victims) {
-        	Grid.Region region = Grid.getCommonRegion(potentialCellIndex, cell.getIndex());
-            result.add(new Potential(cell, p.value, false, p,
-                    getRegionCause(region.getRegionTypeIndex()),
-                    "the value can occur only once in the " + region.toString()));
-        }
-        return result;
+		
+		boolean byRegion = false; //debug: check whether the order of generated potentials makes sense
+		
+		if(! byRegion) {
+			//extract by cell index
+			for(Cell cell : victims) {
+	        	Grid.Region region = Grid.getCommonRegion(potentialCellIndex, cell.getIndex());
+	            result.add(new Potential(cell, p.value, false, p,
+	                    getRegionCause(region.getRegionTypeIndex()),
+	                    "the value can occur only once in the " + region.toString()));
+	        }
+		}
+		else {
+			//extract by regonTypeIndex then by cell index
+			for(int regionTypeIndex = 0; regionTypeIndex < 3; regionTypeIndex++) {
+				CellSet regionVictims = new CellSet(victims);
+				Grid.Region region = Grid.getRegionAt(regionTypeIndex, potentialCellIndex);
+				regionVictims.bits.and(region.regionCellsBitSet);
+				for(Cell cell : victims) {
+		            result.add(new Potential(cell, p.value, false, p,
+		                    getRegionCause(regionTypeIndex),
+		                    "the value can occur only once in the " + region.toString()));
+		        }
+			}
+		}
+
+		return result;
     }
     
     private void addHiddenParentsOfCell(Potential p, Grid grid, Grid source, LinkedSet<Potential> offPotentials) {

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -1298,43 +1298,16 @@ public class Chaining implements IndirectHintProducer {
             return "Forcing Chains & Cycles";
     }
 
-//    private void getPreviousHints(HintsAccumulator accu) throws InterruptedException {
-//        for (ChainingHint hint : lastHints)
-//            accu.add(hint);
-//    }
-
     public void getHints(Grid grid, HintsAccumulator accu) throws InterruptedException {
-    	Iterable<ChainingHint> cachedHints = HintsCache.get(grid, signature);
-    	if(cachedHints != null) {
-        	//System.err.printf("(%d%d%d% d%d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit);
-            for (ChainingHint hint : cachedHints) {
-                accu.add(hint);
-            }
-            return;
-    	}
-    	
-//        if (lastGrid != null && grid.equals(lastGrid)) {
-//        	//System.err.printf("(%d%d%d% d%d %d)\n", isMultipleEnabled ? 1 : 0, isDynamic ? 1 : 0, isNisho ? 1 : 0, level, nestingLimit, lastHints.size());
-//            getPreviousHints(accu);
-//            return;
-//        }
-    	//System.err.print('-');
-        List<ChainingHint> result = getHintList(grid);
-        HintsCache.put(grid, signature, result);
-//        lastGrid = new Grid();
-//        grid.copyTo(lastGrid);
-//        //if(Settings.getInstance().getBestHintOnly()) {
-//        if(accu instanceof SingleHintAccumulator) { 
-//            lastHints = new LinkedHashSet<ChainingHint>();
-//            if(! result.isEmpty()) {
-//            	lastHints.add(result.get(0));
-//            }
-//        }
-//        else {
+    	@SuppressWarnings("unchecked")
+    	Collection<ChainingHint> theHints = (Collection<ChainingHint>)(HintsCache.get(grid, signature));
+    	if(theHints == null) {
+	        List<ChainingHint> result = getHintList(grid);
 	        // This filters hints that are equal:
-        	Collection<ChainingHint> lastHints = new LinkedHashSet<ChainingHint>(result);
-//        }
-        for (IndirectHint hint : lastHints)
+	    	theHints = new LinkedHashSet<ChainingHint>(result);
+	        HintsCache.put(grid, signature, theHints);
+     	}
+        for (Hint hint : theHints)
             accu.add(hint);
     }
 

--- a/diuf/sudoku/solver/rules/chaining/Chaining.java
+++ b/diuf/sudoku/solver/rules/chaining/Chaining.java
@@ -638,7 +638,7 @@ public class Chaining implements IndirectHintProducer {
 		CellSet victims = new CellSet(Grid.visibleCellsSet[potentialCellIndex]);
 		victims.bits.and(dc.digitCells[p.value - 1]);
 		
-		boolean byRegion = false; //debug: check whether the order of generated potentials makes sense
+		boolean byRegion = true; //debug: check whether the order of generated potentials makes sense - yes, it does!
 		
 		if(! byRegion) {
 			//extract by cell index
@@ -655,7 +655,7 @@ public class Chaining implements IndirectHintProducer {
 				CellSet regionVictims = new CellSet(victims);
 				Grid.Region region = Grid.getRegionAt(regionTypeIndex, potentialCellIndex);
 				regionVictims.bits.and(region.regionCellsBitSet);
-				for(Cell cell : victims) {
+				for(Cell cell : regionVictims) {
 		            result.add(new Potential(cell, p.value, false, p,
 		                    getRegionCause(regionTypeIndex),
 		                    "the value can occur only once in the " + region.toString()));

--- a/diuf/sudoku/tools/CommonTuples.java
+++ b/diuf/sudoku/tools/CommonTuples.java
@@ -45,9 +45,11 @@ public class CommonTuples {
     public static BitSet searchCommonTupleLight(BitSet[] candidates, int degree) {
         BitSet result = new BitSet(9);
         for (BitSet candidate : candidates) {
+//            result.or(candidate);
+//            if (candidate.cardinality() == 0)
+//                return null;
+            if (candidate.isEmpty()) return null;
             result.or(candidate);
-            if (candidate.cardinality() == 0)
-                return null;
         }
         if (result.cardinality() == degree)
             return result;

--- a/diuf/sudoku/tools/DigitCells.java
+++ b/diuf/sudoku/tools/DigitCells.java
@@ -1,0 +1,28 @@
+/**
+ * @author Mladen Dobrichev, 2019
+ *
+ */
+package diuf.sudoku.tools;
+
+import java.util.BitSet;
+
+import diuf.sudoku.Grid;
+
+public class DigitCells {
+	public BitSet[] digitCells;
+	public DigitCells(Grid g) {
+		digitCells = new BitSet[9];
+		for(int d = 0; d < 9; d++) {
+			digitCells[d] = new BitSet(81);
+			for(int c = 0; c < 81; c++) {
+				digitCells[d].set(c, g.getCellPotentialValues(c).get(d + 1)); //transpose g
+			}
+		}
+	}
+	public DigitCells(DigitCells old) {
+		digitCells = new BitSet[9];
+		for(int d = 0; d < 9; d++) {
+			digitCells[d] = (BitSet)(old.digitCells[d].clone());
+		}
+	}
+}

--- a/diuf/sudoku/tools/HintsCache.java
+++ b/diuf/sudoku/tools/HintsCache.java
@@ -22,6 +22,8 @@ public class HintsCache {
 	public static void put(Grid grid, String signature, Iterable<ChainingHint> result) {
         Grid gridCopy = new Grid();
         grid.copyTo(gridCopy);
+        gridCopy.clearDigitCells();
+        gridCopy.clearInitialGrid();
         ConcurrentHashMap<String,Iterable<ChainingHint>> empty = new ConcurrentHashMap<String,Iterable<ChainingHint>>();
 		ConcurrentHashMap<String,Iterable<ChainingHint>> item = cache.putIfAbsent(gridCopy, empty);
 		if(item != null) {
@@ -47,5 +49,9 @@ public class HintsCache {
 				}
 			}
 		}
+	}
+	//erase after puzzle is done
+	public static void clear() {
+		cache.clear();
 	}
 }

--- a/diuf/sudoku/tools/HintsCache.java
+++ b/diuf/sudoku/tools/HintsCache.java
@@ -34,6 +34,7 @@ public class HintsCache {
 	
 	//erase inapplicable cache items after grid is advanced to newGrid
 	public static void purge(Grid newGrid) {
+		//cache.clear(); //brute but is slower
 		for(Iterator<Grid> gIter = cache.keySet().iterator(); gIter.hasNext();) {
 			Grid g = gIter.next();
 			for(int i = 0; i < 81; i++) {

--- a/diuf/sudoku/tools/HintsCache.java
+++ b/diuf/sudoku/tools/HintsCache.java
@@ -9,23 +9,22 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 
 import diuf.sudoku.Grid;
-import diuf.sudoku.solver.rules.chaining.ChainingHint;
 
 public class HintsCache {
-	private static ConcurrentHashMap<Grid,ConcurrentHashMap<String,Iterable<ChainingHint>>> cache = new ConcurrentHashMap<>();
+	private static ConcurrentHashMap<Grid,ConcurrentHashMap<String,Object>> cache = new ConcurrentHashMap<>();
 	
-	public static Iterable<ChainingHint> get(Grid grid, String signature) {
-		ConcurrentHashMap<String,Iterable<ChainingHint>> item = cache.get(grid);
+	public static Object get(Grid grid, String signature) {
+		ConcurrentHashMap<String,Object> item = cache.get(grid);
 		if(item == null) return null;
 		return item.get(signature);
 	}
-	public static void put(Grid grid, String signature, Iterable<ChainingHint> result) {
+	public static void put(Grid grid, String signature, Object result) {
         Grid gridCopy = new Grid();
         grid.copyTo(gridCopy);
         gridCopy.clearDigitCells();
         gridCopy.clearInitialGrid();
-        ConcurrentHashMap<String,Iterable<ChainingHint>> empty = new ConcurrentHashMap<String,Iterable<ChainingHint>>();
-		ConcurrentHashMap<String,Iterable<ChainingHint>> item = cache.putIfAbsent(gridCopy, empty);
+        ConcurrentHashMap<String,Object> empty = new ConcurrentHashMap<String,Object>();
+		ConcurrentHashMap<String,Object> item = cache.putIfAbsent(gridCopy, empty);
 		if(item != null) {
 			item.put(signature, result);
 		}

--- a/diuf/sudoku/tools/HintsCache.java
+++ b/diuf/sudoku/tools/HintsCache.java
@@ -1,0 +1,50 @@
+/**
+ * @author Mladen Dobrichev, 2019
+ *
+ */
+package diuf.sudoku.tools;
+
+import java.util.BitSet;
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+
+import diuf.sudoku.Grid;
+import diuf.sudoku.solver.rules.chaining.ChainingHint;
+
+public class HintsCache {
+	private static ConcurrentHashMap<Grid,ConcurrentHashMap<String,Iterable<ChainingHint>>> cache = new ConcurrentHashMap<>();
+	
+	public static Iterable<ChainingHint> get(Grid grid, String signature) {
+		ConcurrentHashMap<String,Iterable<ChainingHint>> item = cache.get(grid);
+		if(item == null) return null;
+		return item.get(signature);
+	}
+	public static void put(Grid grid, String signature, Iterable<ChainingHint> result) {
+        Grid gridCopy = new Grid();
+        grid.copyTo(gridCopy);
+        ConcurrentHashMap<String,Iterable<ChainingHint>> empty = new ConcurrentHashMap<String,Iterable<ChainingHint>>();
+		ConcurrentHashMap<String,Iterable<ChainingHint>> item = cache.putIfAbsent(gridCopy, empty);
+		if(item != null) {
+			item.put(signature, result);
+		}
+		else {
+			empty.put(signature, result);
+		}
+	}
+	
+	//erase inapplicable cache items after grid is advanced to newGrid
+	public static void purge(Grid newGrid) {
+		for(Iterator<Grid> gIter = cache.keySet().iterator(); gIter.hasNext();) {
+			Grid g = gIter.next();
+			for(int i = 0; i < 81; i++) {
+				BitSet pm = (BitSet)g.getCellPotentialValues(i).clone();
+				pm.andNot(newGrid.getCellPotentialValues(i));
+				if(!pm.isEmpty()) {
+					//g has potential that is cleared in newGrid. All associated to g cache entries are obsolete.
+					gIter.remove();
+					break;
+				}
+			}
+		}
+	}
+}

--- a/diuf/sudoku/tools/HintsCache.java
+++ b/diuf/sudoku/tools/HintsCache.java
@@ -14,11 +14,13 @@ public class HintsCache {
 	private static ConcurrentHashMap<Grid,ConcurrentHashMap<String,Object>> cache = new ConcurrentHashMap<>();
 	
 	public static Object get(Grid grid, String signature) {
+		//return null; //debug
 		ConcurrentHashMap<String,Object> item = cache.get(grid);
 		if(item == null) return null;
 		return item.get(signature);
 	}
 	public static void put(Grid grid, String signature, Object result) {
+		//return; //debug
         Grid gridCopy = new Grid();
         grid.copyTo(gridCopy);
         gridCopy.clearDigitCells();
@@ -35,7 +37,7 @@ public class HintsCache {
 	
 	//erase inapplicable cache items after grid is advanced to newGrid
 	public static void purge(Grid newGrid) {
-		//cache.clear(); //brute but is slower
+		//cache.clear(); //debug
 		for(Iterator<Grid> gIter = cache.keySet().iterator(); gIter.hasNext();) {
 			Grid g = gIter.next();
 			for(int i = 0; i < 81; i++) {


### PR DESCRIPTION
This is a draft pull request for use ONLY as placeholder for comments.
The code is NOT ready for merging.

### The improvements done in _nestedChains_ branch compared to _master_
* A new `class DigitCells` that holds alive pencilmarks ordered by value then by cell.
* A new `class HintsCache` that collects hints found by particular algorithm for particular grid state for reusing.
* Two new and _currently unused_ fields in Grid
  - `private Grid initialGrid` - a reference to a grid state after last applied eliminations,
  - `private DigitCells dCells` - a reference to current grid state in `DigitCells` form.
* Cancellation of experimental nesting techniques beyond those used for hardest vanilla puzzles.
* Cancellation of code enclosed in `if (Settings.getInstance().Fixed14Chaining() == 1)`.
* Modifications in `Solver.getBatchDifficulty` required for handling the global `HintsCache`.
* Modifications in `Chaining` including
  - use of locally built instance of `DigitCells` for search acceleration,
  - use of `HintsCache` resulting in almost duplicate of the speed,
  - removal of fields `saveGrid`, `lastGrid`, `lastHints` after replacing functionalities related to them by better ones,
  - introduction of new field `signature` required by `HintsCache`,
  - optimization of some critical loops.

### The changes that are not done but are required before merging
* All instances of solving loop must care about global `HintsCache` reset between puzzles and purge between applying hint eliminations. Reason for not implementing this is the variety of loops that recently appeared and are difficult to track.
* All manual interventions to grid state from GUI must handle (or simply reset) the global `HintsCache`.

### Possible further improvements based on the changes
* Using `Grid.initialGrid` within hints collection algorithm for comparison between initial grid state and eventually locally modified one. Removal of local clones of the grid where possible, or at least reduce cloning to making a local copy instead of making and then restoring a backup.
* Using `Grid.dCells`, after single earlier initialization, in all solving techniques that benefit of it.
* Using `HintsCache` by more techniques after implementing a `signature` for the respective technique.


