### PR TITLE
fix isValueAllGiven to work with latin squares

### DIFF
--- a/diuf/sudoku/gui/SudokuExplainer.java
+++ b/diuf/sudoku/gui/SudokuExplainer.java
@@ -248,7 +248,7 @@ public class SudokuExplainer {
 
     public boolean isValueAllGiven(Grid grid, int value) {
         //Region[] regions = grid.getRegions(Grid.Block.class);
-        Region[] regions = Grid.getRegions(0); //blocks
+        Region[] regions = Grid.getRegions(1); //rows, works with latin sqaures!
         for (Region region : regions) {
             if (!region.contains(grid, value))
                 return false;


### PR DESCRIPTION
Affects the legends on the left (rows) - each numbered row gets grayed out as each number gets solved, e.g. as number 1s solved (9 1s in 9 blocks), row 1 is grayed out.
Switched to checking rows to work with latin squares.
