### PR TITLE
fix Solve step button pressed after grid solved

### DIFF
--- a/diuf/sudoku/gui/SudokuExplainer.java
+++ b/diuf/sudoku/gui/SudokuExplainer.java
@@ -459,12 +459,14 @@ public class SudokuExplainer {
     }
 
     public void applySelectedHints() {
+	  if ( !grid.isSolved() ) {
 		pushGrid();
         for (Hint hint : selectedHints)
             //hint.apply();
         	hint.apply(grid);
         clearHints();
         repaintAll();
+	  }
     }
 
     public void undoStep() {
@@ -472,8 +474,10 @@ public class SudokuExplainer {
     }
 
     public void applySelectedHintsAndContinue() {
+	  if ( !grid.isSolved() ) {
         applySelectedHints();
         getNextHint();
+	  }
     }
 
     private void repaintHintsTree() {


### PR DESCRIPTION
Solve step button can be pressed after grid is solved. So if you press Solve step 10 times, you have to Undo 11 times to undo the last solved cell.
This fix ignores the button press if the grid is solved.