### PR TITLE
Remove isUsingAllTechniques checking, fixes #91

### DIFF
--- a/diuf/sudoku/solver/Solver.java
+++ b/diuf/sudoku/solver/Solver.java
@@ -452,7 +452,7 @@ else {
                 for (HintProducer producer : advancedHintProducers)
                     gatherProducer(previousHints, result, accu, producer);
                 for (HintProducer producer : experimentalHintProducers) {
-                    if (result.isEmpty() && Settings.getInstance().isUsingAllTechniques())
+                    if (result.isEmpty()                                                  )
                         gatherProducer(previousHints, result, accu, producer);
                 }
             }
@@ -494,7 +494,7 @@ else {
                         producer.getHints(grid, accu);
                 }
                 for (IndirectHintProducer producer : experimentalHintProducers) {
-                    if (result.isEmpty() && Settings.getInstance().isUsingAllTechniques())
+                    if (result.isEmpty()                                                 )
                         producer.getHints(grid, accu);
                 }
             }
@@ -549,7 +549,7 @@ else {
                     for (IndirectHintProducer producer : advancedHintProducers)
                         producer.getHints(grid, accu);
                     for (IndirectHintProducer producer : experimentalHintProducers) {
-                        if (Settings.getInstance().isUsingAllTechniques())
+                    //  if (Settings.getInstance().isUsingAllTechniques())
                             producer.getHints(grid, accu);
                     }
                 }

--- a/diuf/sudoku/solver/Solver.java
+++ b/diuf/sudoku/solver/Solver.java
@@ -452,7 +452,7 @@ else {
                 for (HintProducer producer : advancedHintProducers)
                     gatherProducer(previousHints, result, accu, producer);
                 for (HintProducer producer : experimentalHintProducers) {
-                    if (result.isEmpty()                                                  )
+                    if (result.isEmpty()                                                 )
                         gatherProducer(previousHints, result, accu, producer);
                 }
             }


### PR DESCRIPTION
With new solving techniques added, Settings.getInstance().isUsingAllTechniques() now returns false (not all solving techniques are enabled because of variants), thus the experimentalHintProducers (level=4 NestedForcingChain) are not called.
The isUsingAllTechniques() checks are removed.
I've downloaded and built the branched code to check that it fixes issue #91.
